### PR TITLE
fix: reference error while server side rendering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,9 +127,10 @@ export const useScramble = (props: UseScrambleProps) => {
     ignore = [' '],
   } = props;
 
-  const prefersReducedMotion = window.matchMedia(
-    '(prefers-reduced-motion: reduce)'
-  ).matches;
+  const prefersReducedMotion =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
 
   if (prefersReducedMotion) {
     step = text.length;


### PR DESCRIPTION
When using SSR in NextJS, `window` object is not defined. this causes a build error in production.

Tested with NextJS 13.1.6

This change preserves current behavior.